### PR TITLE
Environment variable switch to disable lp/lpw

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ you can: cp something ~/.pwd/favorite
 
 use initials, your brain likes it, for example: mc => myconf, al => archlinux
 
+use the `$NOPWD` environment variable to toggle the initial loading of your saved path:
+```
+$ # this will start a terminal and automatically execute lp/lpw
+$ gnome-terminal
+$ # this will start a terminal without executing lp/lpw. You can still do it manually
+$ NOPWD=1 gnome-terminal
+```
 
 ### Todos
 

--- a/pwdtools.sh
+++ b/pwdtools.sh
@@ -55,8 +55,11 @@ function dpw
 # [ -e "$PWD_DB/start" ] && [ "$(pwd)" = "$HOME" ] && lp start
 # load start path only if parent is term like gnome-term
 if grep term /proc/$PPID/comm &>/dev/null; then
-	lp
-	lpw
+	if test -z $NOPWD
+    then
+        lp
+    	lpw
+    fi
 fi
 
 # gift :

--- a/pwdtools.sh
+++ b/pwdtools.sh
@@ -55,10 +55,10 @@ function dpw
 # [ -e "$PWD_DB/start" ] && [ "$(pwd)" = "$HOME" ] && lp start
 # load start path only if parent is term like gnome-term
 if grep term /proc/$PPID/comm &>/dev/null; then
-	if test -z $NOPWD
+  if test -z $NOPWD
     then
-        lp
-    	lpw
+      lp
+      lpw
     fi
 fi
 


### PR DESCRIPTION
I couldn't use my file manager's "Open Terminal here" feature because `lp` kept changing to `start` after the terminal was started. With my changes you can set the environment variable `$NOPWD` and if it is set, `lp` and `lpw` will not be executed. You can still manually use`pwdtools` like you're used to.

```
$ # this will start a terminal and automatically execute lp/lpw
$ gnome-terminal
$ # this will start a terminal without executing lp/lpw. You can still do it manually
$ NOPWD=1 gnome-terminal
```
